### PR TITLE
Update Microsoft.Data.SqlClient from 5.2.1 to 5.2.2

### DIFF
--- a/DBHelper/DBHelper.vbproj
+++ b/DBHelper/DBHelper.vbproj
@@ -36,7 +36,7 @@
 		<WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="SonarAnalyzer.VisualBasic" Version="9.32.0.97167">
 			<PrivateAssets>all</PrivateAssets>

--- a/DBHelperTests/DBHelperTests.vbproj
+++ b/DBHelperTests/DBHelperTests.vbproj
@@ -25,9 +25,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="SonarAnalyzer.VisualBasic" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Resolves medium-level security issue. See [[5.2.2] | CVE | Update Azure.Identity from 1.11.3 to 1.11.4 by DavoudEshtehari · Pull Request #2648 · dotnet/SqlClient](https://github.com/dotnet/SqlClient/pull/2648)